### PR TITLE
Add basic FastAPI backend and Leaflet/Cesium frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # California-BESS-Procurement-App
-California BESS Procurement + Weather Software 
-Provided a scraped excel database that comprises of 5 different sheets. The first sheet defines California County Data - California County, Service Types, Company Name, link to their Google Contact information, and location on google maps. The second is for Arizona County data and starts by defining Arizona counties, Service type, company name, notes on the company, placeholder company website, and location on google maps. The third sheet is the same for Texas. In the fourth sheet, I have defined the top suppliers of BESS equipment in each of the three states with a little summary about their key presence. This is for different BESS equipment materials. In the fifth sheet, I have listed all the current BESS projects currently being executed and their location and capacity. 
 
-I want to use openstreetmaps api, cesiumJS, free weather api to chart out each of these companies on a 2d and 3d map. The goal is for this to help with local procurement for new BESS (battery energy storage system) by showing local suppliers for materials. How do you intend to implement this
+This repo contains a minimal demo for visualizing BESS suppliers and projects on a map.
+
+## Running
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the FastAPI server:
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+3. Open `http://localhost:8000/` in your browser. Click *Switch to 3D* to see the Cesium view.
+
+The app loads project data from the backend, displays markers using Leaflet, and
+fetches current weather for each site from the `/weather` endpoint.

--- a/backend/data/projects.json
+++ b/backend/data/projects.json
@@ -1,0 +1,7 @@
+[
+  {"id": 1, "name": "Zeta Solar", "client": "Longroad", "location": "Los Banos, California", "lat": 37.0591, "lon": -120.8505},
+  {"id": 2, "name": "Cherry Phase 1", "client": "CIM", "location": "Lemoore, California", "lat": 36.3003, "lon": -119.7829},
+  {"id": 3, "name": "Aquamarine", "client": "CIM", "location": "Stratford, California", "lat": 36.1897, "lon": -119.8237},
+  {"id": 4, "name": "Azalea", "client": "Idemitsu", "location": "Lost Hills, California", "lat": 35.6161, "lon": -119.6935},
+  {"id": 5, "name": "Pelicans Jaw", "client": "SB Energy", "location": "Lost Hills, California", "lat": 35.6161, "lon": -119.6935}
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import json
+import httpx
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+
+app = FastAPI()
+
+DATA_FILE = Path(__file__).parent / 'data' / 'projects.json'
+with DATA_FILE.open() as f:
+    projects = json.load(f)
+
+@app.get('/projects')
+async def get_projects():
+    return projects
+
+@app.get('/weather')
+async def get_weather(lat: float, lon: float):
+    url = f"https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}&current_weather=true"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url)
+    return resp.json().get('current_weather', {})
+
+FRONTEND_DIR = Path(__file__).resolve().parent.parent / 'frontend'
+
+@app.get('/')
+async def serve_index():
+    return FileResponse(FRONTEND_DIR / 'index.html')
+
+app.mount('/static', StaticFiles(directory=FRONTEND_DIR), name='static')

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,67 @@
+let map, viewer, projects;
+const toggleBtn = document.getElementById('toggle');
+const mapDiv = document.getElementById('map');
+const cesiumDiv = document.getElementById('cesiumContainer');
+let showing3D = false;
+
+async function fetchProjects() {
+    const res = await fetch('/projects');
+    return res.json();
+}
+
+async function fetchWeather(lat, lon) {
+    const res = await fetch(`/weather?lat=${lat}&lon=${lon}`);
+    return res.json();
+}
+
+function initLeaflet() {
+    map = L.map('map').setView([37.5, -120], 6);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '© OpenStreetMap contributors'
+    }).addTo(map);
+    projects.forEach(p => {
+        const m = L.marker([p.lat, p.lon]).addTo(map);
+        m.on('click', async () => {
+            const weather = await fetchWeather(p.lat, p.lon);
+            m.bindPopup(`<b>${p.name}</b><br>${p.location}<br>Temp: ${weather.temperature}\xB0C`).openPopup();
+        });
+    });
+}
+
+function initCesium() {
+    viewer = new Cesium.Viewer('cesiumContainer', {
+        imageryProvider: new Cesium.UrlTemplateImageryProvider({
+            url: 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        }),
+        baseLayerPicker: false
+    });
+    projects.forEach(p => {
+        viewer.entities.add({
+            position: Cesium.Cartesian3.fromDegrees(p.lon, p.lat),
+            point: { pixelSize: 10, color: Cesium.Color.RED },
+            description: `<b>${p.name}</b><br>${p.location}`
+        });
+    });
+    viewer.zoomTo(viewer.entities);
+}
+
+async function toggle() {
+    showing3D = !showing3D;
+    if (showing3D) {
+        mapDiv.style.display = 'none';
+        cesiumDiv.style.display = 'block';
+        toggleBtn.textContent = 'Switch to 2D';
+        if (!viewer) initCesium();
+    } else {
+        cesiumDiv.style.display = 'none';
+        mapDiv.style.display = 'block';
+        toggleBtn.textContent = 'Switch to 3D';
+    }
+}
+
+toggleBtn.addEventListener('click', toggle);
+
+fetchProjects().then(data => {
+    projects = data;
+    initLeaflet();
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>BESS Map</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link href="https://cdn.jsdelivr.net/npm/cesium@1.118/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+    <style>
+        body { margin:0; padding:0; }
+        #map, #cesiumContainer { width:100%; height:600px; }
+    </style>
+</head>
+<body>
+    <button id="toggle">Switch to 3D</button>
+    <div id="map"></div>
+    <div id="cesiumContainer" style="display:none;"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/cesium@1.118/Build/Cesium/Cesium.js"></script>
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx


### PR DESCRIPTION
## Summary
- add minimal FastAPI backend to serve project data and weather
- create static frontend with Leaflet 2D map and Cesium 3D toggle
- include sample project data with coordinates
- document how to run the demo

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `uvicorn backend.main:app --port 8000 --reload` *(fails: uvicorn not installed -> installed packages, ran server, fetched index)*

------
https://chatgpt.com/codex/tasks/task_e_6881267585a88322bc45b2b3ec7bdbb9