### PR TITLE
Fix map layout and parse lat/lon columns

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,7 +26,7 @@
 
     /* toolbar bar at top */
     #toolbar {
-      position: absolute;
+      position: fixed;
       top: 0; left: 0;
       width: 100%;
       height: 50px;
@@ -62,9 +62,8 @@
     #map,
     #cesiumContainer {
       position: absolute;
-      top: 50px; left: 0;
+      top: 50px; left: 0; right: 0; bottom: 0;
       width: 100%;
-      height: calc(100% - 50px);
     }
     #cesiumContainer { display: none; }
 
@@ -297,6 +296,7 @@
         cesDiv.style.display = 'none';
         mapDiv.style.display = 'block';
         btn.textContent = 'Switch to 3D';
+        if (leafletMap) leafletMap.invalidateSize();
       }
     };
     document.getElementById('searchBtn').onclick = () => doSearch(


### PR DESCRIPTION
## Summary
- fill the map container across the viewport by tweaking CSS and pinning the toolbar
- invalidate Leaflet size when switching views
- parse latitude/longitude columns if present

## Testing
- `python -m py_compile backend/parse_excel.py`
- `python -m py_compile backend/main.py`
- `python backend/parse_excel.py`

------
https://chatgpt.com/codex/tasks/task_e_6882834a0230832290cae5b3113aefea